### PR TITLE
update bubble mixin with color parameters

### DIFF
--- a/scss/_bubbles.scss
+++ b/scss/_bubbles.scss
@@ -1,13 +1,13 @@
-@use './mixins/bubble' as *;
+@use "./mixins/bubble" as *;
 
 .bubble-lg {
-  @include bubble(230);
+  @include bubble(230, var.$lavender60, var.$lavender100);
 }
 
 .bubble-md {
-  @include bubble(135);
+  @include bubble(135, var.$lavender60, var.$lavender100);
 }
 
 .bubble-sm {
-  @include bubble(45);
+  @include bubble(45, var.$lavender60, var.$lavender100);
 }

--- a/scss/_bubbles.scss
+++ b/scss/_bubbles.scss
@@ -1,13 +1,14 @@
 @use "./mixins/bubble" as *;
+@use "./variables" as var;
 
 .bubble-lg {
-  @include bubble(230, var.$lavender60, var.$lavender100);
+  @include bubble(230, var.$lavender100);
 }
 
 .bubble-md {
-  @include bubble(135, var.$lavender60, var.$lavender100);
+  @include bubble(135, var.$lavender100);
 }
 
 .bubble-sm {
-  @include bubble(45, var.$lavender60, var.$lavender100);
+  @include bubble(45, var.$lavender100);
 }

--- a/scss/_bubbles.scss
+++ b/scss/_bubbles.scss
@@ -1,14 +1,14 @@
 @use "./mixins/bubble" as *;
-@use "./variables" as var;
+@use "./variables" as *;
 
 .bubble-lg {
-  @include bubble(230, var.$lavender100);
+  @include bubble(230, $lavenders);
 }
 
 .bubble-md {
-  @include bubble(135, var.$lavender100);
+  @include bubble(135, $lavenders);
 }
 
 .bubble-sm {
-  @include bubble(45, var.$lavender100);
+  @include bubble(45, $lavenders);
 }

--- a/scss/mixins/_bubble.scss
+++ b/scss/mixins/_bubble.scss
@@ -1,8 +1,15 @@
 @use "../variables" as *;
 
-@mixin bubble($diameter: 230, $color) {
+@mixin bubble($diameter: 230, $color-map) {
+  $lighterTone: map-get($color-map, "60");
+  $darkerTone: map-get($color-map, "100");
+
   height: $diameter * 1px;
   width: $diameter * 1px;
   border-radius: 100%;
-  background: linear-gradient(135deg, $lavender60 0%, rgba($color, 0) 100%);
+  background: linear-gradient(
+    135deg,
+    $lighterTone 0%,
+    rgba($darkerTone, 0) 100%
+  );
 }

--- a/scss/mixins/_bubble.scss
+++ b/scss/mixins/_bubble.scss
@@ -1,8 +1,8 @@
 @use "../variables" as *;
 
-@mixin bubble($diameter: 230, $lightColor, $darkcolor) {
+@mixin bubble($diameter: 230, $color) {
   height: $diameter * 1px;
   width: $diameter * 1px;
   border-radius: 100%;
-  background: linear-gradient(135deg, $lightColor 0%, rgba($darkcolor, 0) 100%);
+  background: linear-gradient(135deg, $lavender60 0%, rgba($color, 0) 100%);
 }

--- a/scss/mixins/_bubble.scss
+++ b/scss/mixins/_bubble.scss
@@ -1,12 +1,8 @@
-@use '../variables' as *;
+@use "../variables" as *;
 
-@mixin bubble($diameter: 230) {
+@mixin bubble($diameter: 230, $lightColor, $darkcolor) {
   height: $diameter * 1px;
   width: $diameter * 1px;
   border-radius: 100%;
-  background: linear-gradient(
-    135deg,
-    $lavender60 0%,
-    rgba($lavender100, 0) 100%
-  );
+  background: linear-gradient(135deg, $lightColor 0%, rgba($darkcolor, 0) 100%);
 }


### PR DESCRIPTION
- Updated the bubble mixin with two color parameter, one for the lighter tone and one for the darker tone in the gradient. 
- Added the lavender color variables as parameters in the bubble-lg/md/sm classes. 

The code for the updated mixin:

<img width="619" alt="Screenshot 2025-03-27 at 17 14 17" src="https://github.com/user-attachments/assets/a3e23852-be14-42a5-864e-8918a8a8446e" />

Added to the .bubble classes:
<img width="426" alt="Screenshot 2025-03-27 at 16 55 57" src="https://github.com/user-attachments/assets/4992b54b-7f39-44a3-9d18-eb3b1704c160" />



How the bubbles look: 

![Screenshot 2025-03-27 at 16 55 43](https://github.com/user-attachments/assets/4a2b7dad-4b6d-4812-ae4f-3ef3f66a807c)




