### PR TITLE
update bubble mixin to take map as parameter

### DIFF
--- a/scss/_bubbles.scss
+++ b/scss/_bubbles.scss
@@ -1,8 +1,6 @@
 @use "./mixins/bubble" as *;
 @use "./variables" as *;
 
-@use "./variables" as *;
-
 .bubble-lg {
   @include bubble(230, $lavenders);
 }

--- a/scss/_bubbles.scss
+++ b/scss/_bubbles.scss
@@ -1,13 +1,16 @@
-@use './mixins/bubble' as *;
+@use "./mixins/bubble" as *;
+@use "./variables" as *;
+
+@use "./variables" as *;
 
 .bubble-lg {
-  @include bubble(230);
+  @include bubble(230, $lavenders);
 }
 
 .bubble-md {
-  @include bubble(135);
+  @include bubble(135, $lavenders);
 }
 
 .bubble-sm {
-  @include bubble(45);
+  @include bubble(45, $lavenders);
 }

--- a/scss/mixins/_bubble.scss
+++ b/scss/mixins/_bubble.scss
@@ -1,12 +1,15 @@
-@use '../variables' as *;
+@use "../variables" as *;
 
-@mixin bubble($diameter: 230) {
+@mixin bubble($diameter: 230, $color-map) {
+  $lighterTone: map-get($color-map, "60");
+  $darkerTone: map-get($color-map, "100");
+
   height: $diameter * 1px;
   width: $diameter * 1px;
   border-radius: 100%;
   background: linear-gradient(
     135deg,
-    $lavender60 0%,
-    rgba($lavender100, 0) 100%
+    $lighterTone 0%,
+    rgba($darkerTone, 0) 100%
   );
 }


### PR DESCRIPTION
**The code:**

```css
@use "../variables" as *;

@mixin bubble($diameter: 230, $color-map) {
  $lighterTone: map-get($color-map, "60");
  $darkerTone: map-get($color-map, "100");

  height: $diameter * 1px;
  width: $diameter * 1px;
  border-radius: 100%;
  background: linear-gradient(
    135deg,
    $lighterTone 0%,
    rgba($darkerTone, 0) 100%
  );
}
```

**Applied in classes:**

```css
.bubble-lg {
  @include bubble(230, $lavenders);
}

.bubble-md {
  @include bubble(135, $skys);
}

.bubble-sm {
  @include bubble(45, $oceans);
}

```

**The result:**

<img width="727" alt="Screenshot 2025-03-28 at 09 09 29" src="https://github.com/user-attachments/assets/fe178f24-2926-4c0a-922b-5d6ee8b7800f" />
