### PR TITLE
add description about the new bubble mixin

### DIFF
--- a/docs/src/content/docs/components/bubbles.mdx
+++ b/docs/src/content/docs/components/bubbles.mdx
@@ -23,14 +23,34 @@ Bubbles are purely decorative elements used in the OpenAQ website and OpenAQ exp
 <div class="bubbles-mixin-wrapper">
   <h2 class="bubbles-mixin-heading">Mixin</h2>
 
-In addition to the base classes, bubbles can be created with a mixin. The mixin takes a diameter parameter with a default of 230px, the same at the large bubble.
+In addition to the base classes, bubbles can be created using the bubble mixin. The mixin takes two parameters:
+
+<ul>
+  <li>Diameter – the size of the bubble in pixels (e.g. 230)</li>
+  <li>Color – a color map variable from the design system (e.g. $skys)</li>
+</ul>
+
+Example:
+
+<div class="bubbles-container">
+  <div class="bubble-sm"></div>
+  <div class="bubble-lg"></div>
+</div>
 
 </div>
-```scss
-@use "openaq-design-system/mixins" as mixins;
-
-@include mixins.bubble(300);
 
 ```
+  @use "openaq-design-system/scss/mixins/bubble" as mixins;
+  @use "openaq-design-system/scss/variables" as var;
+
+.bubbles-container {
+  .bubble-lg {
+    @include mixins.bubble(230, var.$skys);
+  }
+
+  .bubble-sm {
+    @include mixins.bubble(45, var.$skys);
+  }
+}
 
 ```

--- a/docs/src/styles/main.scss
+++ b/docs/src/styles/main.scss
@@ -278,6 +278,20 @@ span {
   padding-top: 20px;
 }
 
+.bubbles-container {
+  display: flex;
+  gap: 20px;
+
+  .bubble-lg {
+    @include mixins.bubble(230, var.$skys);
+    margin-bottom: 20px;
+  }
+
+  .bubble-sm {
+    @include mixins.bubble(45, var.$skys);
+  }
+}
+
 /*** FOOTER ***/
 
 footer {


### PR DESCRIPTION
Added a description of the mixin + included it visually:

<img width="736" alt="Screenshot 2025-05-16 at 07 58 14" src="https://github.com/user-attachments/assets/6015e5ea-2742-450e-a049-15e2279e39e4" />

Added in code how to use the mixin:

```css

  @use "openaq-design-system/scss/mixins/bubble" as mixins;
  @use "openaq-design-system/scss/variables" as var;

.bubbles-container {
  .bubble-lg {
    @include mixins.bubble(230, var.$skys);
  }

  .bubble-sm {
    @include mixins.bubble(45, var.$skys);
  }
}

```

<img width="719" alt="Screenshot 2025-05-16 at 07 58 38" src="https://github.com/user-attachments/assets/c217a044-1c08-4728-8213-5ef7671e057b" />
